### PR TITLE
Sign electron app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ out/
 
 build/
 dist/
+build-dependencies/scripts/set-build-secrets.sh

--- a/build-config/forge/forge.config.js
+++ b/build-config/forge/forge.config.js
@@ -1,3 +1,6 @@
+const { notarize } = require('electron-notarize');
+const path = require('path');
+
 module.exports = {
     makers: [
         {
@@ -19,11 +22,44 @@ module.exports = {
             config: {},
         },
     ],
-    "packagerConfig": {
-        protocols: [{"name": "Peak", "schemes": ["peak-dev-app", "peak-app"]}],
-        name: "Peak",
-        executableName: "Peak",
-        "icon": "./src/assets/logos/electron-icons/mac/icon.icns"
+    packagerConfig: {
+        asar: true,
+        "protocols": [{"name": "Peak", "schemes": ["peak-dev-app", "peak-app"]}],
+        "name": "Peak",
+        "executableName": "Peak",
+        "dmg": {
+            "sign": false,
+        },
+        "osxSign": {
+            "identity": process.env.APPLE_DEVELOPER_IDENTITY,
+            "hardenedRuntime": true,
+            "gatekeeper-assess": false,
+            "entitlements": "./build-dependencies/resources/entitlements.mac.plist",
+            "entitlementsInherits": "./build-dependencies/resources/entitlements.mac.plist"
+        },
+        "osxNotarize": {
+            "appleId": process.env.APPLE_ID,
+            "appleIdPassword": process.env.APPLE_ID_PASSWORD
+        },
+        "icon": "./src/assets/logos/electron-icons/mac/icon.icns",
+        packageManager: 'yarn'
+    },
+    "hooks": {
+        "postPackage": async function (params) {
+            console.log('postPackage hook triggered');
+
+            if (process.platform !== 'darwin') {
+                console.log('Skipping notarization - not building for Mac');
+                return;
+            }
+
+            await notarize({
+                // appBundleId: "com.massive.peak",
+                appPath: path.join("out", "Peak-darwin-x64", "Peak.app"),
+                appleId: process.env.APPLE_ID,
+                appleIdPassword: process.env.APPLE_ID_PASSWORD
+            });
+        }
     },
     "plugins": [
         [

--- a/build-dependencies/resources/entitlements.mac.plist
+++ b/build-dependencies/resources/entitlements.mac.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+  </dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "peak-app",
   "productName": "Peak",
   "version": "0.0.1-beta-1",
+  "repository": "DevonPeroutky/peak-app",
   "description": "Your Peakiest Peak",
   "main": "./.webpack/main",
   "scripts": {
@@ -126,6 +127,7 @@
     "slate-hyperscript": "^0.59.0",
     "slate-react": "^0.59.0",
     "styled-components": "^5.1.1",
+    "update-electron-app": "^2.0.1",
     "uuid": "^8.3.0",
     "webpack-manifest-plugin": "^2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "peak-app",
   "productName": "Peak",
-  "version": "0.0.1-beta-1",
+  "version": "0.0.1-beta-2",
   "repository": "DevonPeroutky/peak-app",
   "description": "Your Peakiest Peak",
   "main": "./.webpack/main",
@@ -41,6 +41,7 @@
     "cpy": "^8.1.1",
     "css-loader": "^4.3.0",
     "electron": "10.1.3",
+    "electron-notarize": "^1.0.0",
     "electron-webpack-ts": "^4.0.1",
     "eslint-plugin-import": "^2.20.0",
     "file-loader": "^6.1.0",

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -1,6 +1,8 @@
 import {app, BrowserWindow, shell, globalShortcut, ipcMain} from 'electron';
 import * as isDev from 'electron-is-dev';
 import config from "../constants/environment-vars"
+require('update-electron-app')()
+
 const { Deeplink } = require('electron-deeplink');
 const log = require('electron-log');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6424,6 +6424,11 @@ electron-installer-redhat@^3.2.0:
     word-wrap "^1.2.3"
     yargs "^15.1.0"
 
+electron-is-dev@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-0.3.0.tgz#14e6fda5c68e9e4ecbeff9ccf037cbd7c05c5afe"
+  integrity sha1-FOb9pcaOnk7L7/nM8DfL18BcWv4=
+
 electron-is-dev@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-1.2.0.tgz#2e5cea0a1b3ccf1c86f577cee77363ef55deb05e"
@@ -7898,6 +7903,13 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+github-url-to-object@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/github-url-to-object/-/github-url-to-object-4.0.4.tgz#a9797b7026e18d53b50b07f45b7e169b55fd90ee"
+  integrity sha512-1Ri1pR8XTfzLpbtPz5MlW/amGNdNReuExPsbF9rxLsBfO1GH9RtDBamhJikd0knMWq3RTTQDbTtw0GGvvEAJEA==
+  dependencies:
+    is-url "^1.1.0"
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -9176,6 +9188,11 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-url@^1.1.0, is-url@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
 
 is-utf8@^0.2.0:
   version "0.2.1"
@@ -16190,6 +16207,16 @@ upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
+update-electron-app@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/update-electron-app/-/update-electron-app-2.0.1.tgz#229dbeb4534f51ec949e6a46ae1ac32f68a17eed"
+  integrity sha512-e4xEner89UZZaBGYJbYlMdL1uUrC0VjOsTAL2N4opPjzFtn+j7mdsJJsnyXZzUVeLY+8tuCX4XEsUM98oBHmZg==
+  dependencies:
+    electron-is-dev "^0.3.0"
+    github-url-to-object "^4.0.4"
+    is-url "^1.2.4"
+    ms "^2.1.1"
 
 uri-js@^4.2.2:
   version "4.4.0"


### PR DESCRIPTION
## Changes
- Added ability to sign and notarize our electron app as part of the publish process.
- Need to run `./build-dependencies/scripts/set-build-secrets.sh` in order to set env variables. This is not checked into source control as it contains mostly secrets