### PR TITLE
Simplify NodeContentSelect onKeyDown

### DIFF
--- a/src/chrome-extension/content-script/utils/drawerUtils.tsx
+++ b/src/chrome-extension/content-script/utils/drawerUtils.tsx
@@ -9,7 +9,7 @@ import {SubmitNoteMessage} from "../../constants/models";
 import {sleep} from "../../utils/generalUtil";
 import {Node} from "slate";
 import {SaveNoteDrawer, SaveNoteDrawerProps} from "../components/save-note-modal/SaveNoteDrawer";
-import {isEmpty} from "ramda";
+import {is, isEmpty} from "ramda";
 import {syncCurrentDrawerState} from "./messageUtils";
 import {INITIAL_PAGE_STATE} from "../../../constants/editor";
 
@@ -33,8 +33,11 @@ export function openDrawer(currTab: Tab, userId: string, tags: PeakTag[]): void 
         ReactDOM.render(<SaveNoteDrawer {...props} />, app)
     }
 
-    chrome.storage.sync.get([currTab.id.toString()], (data) => {
-        if (isEmpty(data)) {
+    chrome.storage.sync.get(null, (data) => {
+        console.log(data)
+        const isTabActive = data[currTab.id.toString()]
+        console.log(`Tab active? `, isTabActive)
+        if (!isTabActive) {
             console.log(`Creating New Drawer`)
             createDrawer(currTab.id, false)
             syncCurrentDrawerState(currTab.id, userId, [], currTab.title, currTab.url, currTab.favIconUrl, INITIAL_PAGE_STATE.body as Node[])

--- a/src/common/rich-text-editor/editors/note-editor/config.ts
+++ b/src/common/rich-text-editor/editors/note-editor/config.ts
@@ -4,7 +4,8 @@ import {
     withInlineVoid,
 } from "@udecode/slate-plugins";
 import {
-    setEditorNormalizers, setEditorPlugins,
+    setEditorNormalizers,
+    setEditorPlugins,
 } from "../../base_config";
 
 // Default

--- a/src/common/rich-text-editor/utils/node-content-select/useNodeContentSelect.tsx
+++ b/src/common/rich-text-editor/utils/node-content-select/useNodeContentSelect.tsx
@@ -22,6 +22,7 @@ import {useCurrentUser} from "../../../../utils/hooks";
 import {ELEMENT_PEAK_BOOK, PEAK_BOOK_SELECT_ITEM} from "../../plugins/peak-knowledge-plugin/constants";
 import {isAtTopLevelOfEditor} from "../base-utils";
 import {OpenLibraryBook, useDebounceOpenLibrarySearcher} from "../../../../client/openLibrary";
+import {useSlate} from "slate-react";
 
 interface PeakNodeSelectMenuOptions extends UseMentionOptions {
     editorLevel: number
@@ -112,43 +113,43 @@ export const useNodeContentSelect = (
         [options, targetRange]
     );
 
-    const onKeyDownMention = useCallback((e, editor: Editor, books: OpenLibraryBook[]) => {
-        const totalMax: number = Math.max(values.length, 1) + library.length - 1
-        if (targetRange) {
-            if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                return setValueIndex(getNextIndex(valueIndex, totalMax));
-            }
-            if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                return setValueIndex(getPreviousIndex(valueIndex, totalMax));
-            }
-            if (e.key === 'Escape') {
-                e.preventDefault();
-                resetNodeMenuItem();
-                return setTargetRange(null);
-            }
+    const onKeyDownSelect = useCallback((e, editor: Editor) => {
+            const totalMax: number = Math.max(values.length, 1) + library.length - 1
+            if (targetRange) {
+                if (e.key === 'ArrowDown') {
+                    e.preventDefault();
+                    return setValueIndex(getNextIndex(valueIndex, totalMax));
+                }
+                if (e.key === 'ArrowUp') {
+                    e.preventDefault();
+                    return setValueIndex(getPreviousIndex(valueIndex, totalMax));
+                }
+                if (e.key === 'Escape') {
+                    e.preventDefault();
+                    resetNodeMenuItem();
+                    return setTargetRange(null);
+                }
 
-            if (e.key === 'Backspace' && search.length === 0) {
-                resetNodeMenuItem();
-                return setTargetRange(null);
-            }
+                if (e.key === 'Backspace' && search.length === 0) {
+                    resetNodeMenuItem();
+                    return setTargetRange(null);
+                }
 
-            if (['Tab', 'Enter'].includes(e.key)) {
-                e.preventDefault();
-                if (values.length) {
-                    console.log(`Values `, values)
-                    console.log(`Books `, books)
-                    console.log(`ValueIndex `, valueIndex)
-                    const fullOptions: PeakNodeSelectListItem[] = [...values, ...books.map(convertOpenLibraryBookToNodeSelectListItem)]
-                    onAddNodeContent(editor, fullOptions[valueIndex])
-                    return false
-                } else {
-                    Editor.insertBreak(editor)
+                if (['Tab', 'Enter'].includes(e.key)) {
+                    e.preventDefault();
+                    if (values.length) {
+                        console.log(`Values `, values)
+                        console.log(`Books `, books)
+                        console.log(`ValueIndex `, valueIndex)
+                        const fullOptions: PeakNodeSelectListItem[] = [...values, ...library.map(convertOpenLibraryBookToNodeSelectListItem)]
+                        onAddNodeContent(editor, fullOptions[valueIndex])
+                        return false
+                    } else {
+                        Editor.insertBreak(editor)
+                    }
                 }
             }
-        }
-    },[
+        },[
             values,
             valueIndex,
             library,
@@ -225,7 +226,7 @@ export const useNodeContentSelect = (
         values,
         openLibraryResults: library,
         onChangeMention,
-        onKeyDownMention,
+        onKeyDownSelect,
         onAddNodeContent,
         nodeContentSelectMode
     };

--- a/src/views/journal/Journal.tsx
+++ b/src/views/journal/Journal.tsx
@@ -204,7 +204,6 @@ const PeakJournal = (props: { }) => {
                 values={values}
                 nodeContentSelectMode={nodeContentSelectMode}
                 onAddNodeContent={onAddNodeContent}/>
-
         }
     }
 

--- a/src/views/journal/Journal.tsx
+++ b/src/views/journal/Journal.tsx
@@ -151,7 +151,7 @@ const PeakJournal = (props: { }) => {
         openLibraryResults,
         onAddNodeContent,
         onChangeMention,
-        onKeyDownMention,
+        onKeyDownSelect,
         search,
         index,
         target,
@@ -163,7 +163,7 @@ const PeakJournal = (props: { }) => {
     });
     function keyBindingHandler(event): void | false {
         baseKeyBindingHandler(event, editor)
-        return onKeyDownMention(event, editor, openLibraryResults)
+        return onKeyDownSelect(event, editor)
     }
 
     const syncJournalEntries = (newValue: Node[]) => {
@@ -233,7 +233,7 @@ interface InternalJournalProps {
     // Random
     // TODO: This doesn't feel like something we should have to pass
     currentPageId: string,
-    keyBindingHandler: (e, editor: Editor, books: OpenLibraryBook[]) => void,
+    keyBindingHandler: (e, editor: Editor) => void,
 
     // Node Content Select Props
     // TODO: This doesn't feel like something we should have to pass
@@ -276,7 +276,7 @@ const Journal = (props: InternalJournalProps) => {
                 showLinkMenu={editorState.showLinkMenu}
                 pageId={currentPageId}/>
             <EditablePlugins
-                onKeyDown={[(e, editor) => keyBindingHandler(e, editor, openLibraryBooks)]}
+                onKeyDown={[(e, editor) => keyBindingHandler(e, editor)]}
                 onKeyDownDeps={[index, search, target, openLibraryBooks]}
                 style={{
                     textAlign: "left",

--- a/src/views/notes/note-view/note-editor/PeakNoteEditor.tsx
+++ b/src/views/notes/note-view/note-editor/PeakNoteEditor.tsx
@@ -64,7 +64,7 @@ export const PeakNoteEditor = (props) => {
 
     const nodeSelectMenuKeyBindingHandler = useCallback((event: any) => {
         return onKeyDownMention(event, editor, openLibraryResults)
-    }, [index, search, target])
+    }, [index, search, target, openLibraryResults])
 
     console.log("Re-Rendering Note Content", noteContent)
 

--- a/src/views/notes/note-view/note-editor/PeakNoteEditor.tsx
+++ b/src/views/notes/note-view/note-editor/PeakNoteEditor.tsx
@@ -42,7 +42,7 @@ export const PeakNoteEditor = (props) => {
         onAddNodeContent,
         openLibraryResults,
         onChangeMention,
-        onKeyDownMention,
+        onKeyDownSelect,
         search,
         index,
         target,
@@ -56,15 +56,6 @@ export const PeakNoteEditor = (props) => {
     const defaultKeyBindingHandler = useCallback((event: any) => {
         baseKeyBindingHandler(event, editor)
     }, [])
-
-    // function keyBindingHandler(event): void | false {
-    //     baseKeyBindingHandler(event, editor)
-    //     return onKeyDownMention(event, editor, openLibraryResults)
-    // }
-
-    const nodeSelectMenuKeyBindingHandler = useCallback((event: any) => {
-        return onKeyDownMention(event, editor, openLibraryResults)
-    }, [index, search, target, openLibraryResults])
 
     console.log("Re-Rendering Note Content", noteContent)
 
@@ -86,7 +77,7 @@ export const PeakNoteEditor = (props) => {
                     <PageContextBar topicId={topic_id}/>
                     */}
                     <EditablePlugins
-                        onKeyDown={[defaultKeyBindingHandler, nodeSelectMenuKeyBindingHandler]}
+                        onKeyDown={[defaultKeyBindingHandler, (e) => onKeyDownSelect(e, editor)]}
                         onKeyDownDeps={[index, search, target, openLibraryResults]}
                         key={`${currentPageId}-${editorState.isEditing}`}
                         plugins={notePlugins}

--- a/src/views/notes/note-view/note-editor/PeakNoteEditor.tsx
+++ b/src/views/notes/note-view/note-editor/PeakNoteEditor.tsx
@@ -33,16 +33,15 @@ export const PeakNoteEditor = (props) => {
     const updateNoteContent = (newBody: Node[]) => {
         setNoteContent(newBody)
         noteSaver(currentUser.id, currentNote.id, { body: newBody[0]["children"] as Node[] })
+        onChangeMention(editor);
     }
-    const defaultKeyBindingHandler = useCallback((event: any) => {
-        baseKeyBindingHandler(event, editor)
-    }, [])
 
     // PeakInlineSelect nonsense
     const {
         values,
         onAddNodeContent,
         openLibraryResults,
+        onChangeMention,
         onKeyDownMention,
         search,
         index,
@@ -54,10 +53,18 @@ export const PeakNoteEditor = (props) => {
         trigger: '/',
     });
 
-    function keyBindingHandler(event): void | false {
+    const defaultKeyBindingHandler = useCallback((event: any) => {
         baseKeyBindingHandler(event, editor)
+    }, [])
+
+    // function keyBindingHandler(event): void | false {
+    //     baseKeyBindingHandler(event, editor)
+    //     return onKeyDownMention(event, editor, openLibraryResults)
+    // }
+
+    const nodeSelectMenuKeyBindingHandler = useCallback((event: any) => {
         return onKeyDownMention(event, editor, openLibraryResults)
-    }
+    }, [index, search, target])
 
     console.log("Re-Rendering Note Content", noteContent)
 
@@ -79,7 +86,7 @@ export const PeakNoteEditor = (props) => {
                     <PageContextBar topicId={topic_id}/>
                     */}
                     <EditablePlugins
-                        onKeyDown={[defaultKeyBindingHandler, keyBindingHandler]}
+                        onKeyDown={[defaultKeyBindingHandler, nodeSelectMenuKeyBindingHandler]}
                         onKeyDownDeps={[index, search, target, openLibraryResults]}
                         key={`${currentPageId}-${editorState.isEditing}`}
                         plugins={notePlugins}

--- a/src/views/notes/notes-list/note-list-view.scss
+++ b/src/views/notes/notes-list/note-list-view.scss
@@ -60,7 +60,7 @@
               .item-title {
                 line-height: 32px;
                 font-size: 24px;
-
+                font-weight: normal;
               }
             }
           }

--- a/src/views/wiki/TopicWiki.tsx
+++ b/src/views/wiki/TopicWiki.tsx
@@ -35,7 +35,7 @@ const TopicWiki = (props: {topic_id: string}) => {
         openLibraryResults,
         onAddNodeContent,
         onChangeMention,
-        onKeyDownMention,
+        onKeyDownSelect,
         search,
         index,
         target,
@@ -45,9 +45,6 @@ const TopicWiki = (props: {topic_id: string}) => {
         maxSuggestions: 10,
         trigger: '/',
     });
-    const nodeSelectMenuKeyBindingHandler = useCallback((event: any) => {
-        return onKeyDownMention(event, editor, openLibraryResults)
-    }, [index, search, target, openLibraryResults])
 
     useHotkeys('e, command+s', (event, handler) => {
         switch (handler.key) {
@@ -111,7 +108,7 @@ const TopicWiki = (props: {topic_id: string}) => {
                 <div className={"rich-text-editor-container"}>
                     <PageContextBar topicId={topic_id}/>
                     <EditablePlugins
-                        onKeyDown={[defaultKeyBindingHandler, nodeSelectMenuKeyBindingHandler]}
+                        onKeyDown={[defaultKeyBindingHandler, (e) => onKeyDownSelect(e, editor)]}
                         onKeyDownDeps={[index, search, target, openLibraryResults]}
                         key={`${currentPageId}-${editorState.isEditing}`}
                         plugins={wikiPlugins}

--- a/src/views/wiki/TopicWiki.tsx
+++ b/src/views/wiki/TopicWiki.tsx
@@ -47,7 +47,7 @@ const TopicWiki = (props: {topic_id: string}) => {
     });
     const nodeSelectMenuKeyBindingHandler = useCallback((event: any) => {
         return onKeyDownMention(event, editor, openLibraryResults)
-    }, [index, search, target])
+    }, [index, search, target, openLibraryResults])
 
     useHotkeys('e, command+s', (event, handler) => {
         switch (handler.key) {
@@ -112,7 +112,7 @@ const TopicWiki = (props: {topic_id: string}) => {
                     <PageContextBar topicId={topic_id}/>
                     <EditablePlugins
                         onKeyDown={[defaultKeyBindingHandler, nodeSelectMenuKeyBindingHandler]}
-                        onKeyDownDeps={[index, search, target]}
+                        onKeyDownDeps={[index, search, target, openLibraryResults]}
                         key={`${currentPageId}-${editorState.isEditing}`}
                         plugins={wikiPlugins}
                         placeholder="Drop some knowledge..."


### PR DESCRIPTION
## Changes
- Simplify NodeContentSelect onKeyDown to use the deps on the hook sensibly
- Include the NodeContentSelect for NoteView