### PR TITLE
Update how app_server and backend_server are specified from env_vars

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -5,7 +5,7 @@ import config from "../src/constants/environment-vars"
 import { autoUpdater } from "electron-updater"
 
 const { Deeplink } = require('electron-deeplink');
-const protocol = config.protocol;
+const protocol = config.electron_protocol;
 
 // on macOS: ~/Library/Logs/{app name}/{process type}.log
 const log = require('electron-log');

--- a/src/client/axiosConfig.ts
+++ b/src/client/axiosConfig.ts
@@ -1,9 +1,9 @@
 import axios from 'axios';
-import {backend_host_address} from "../constants/constants";
+import config from "../constants/environment-vars"
 
 const defaultConfig = {
     withCredentials: true,
-    baseURL: `http://${backend_host_address}`
+    baseURL: `${config.web_protocol}${config.backend_domain}`
 }
 const authedAxiosClient = axios.create(defaultConfig);
 

--- a/src/common/login/signin-button/desktop-google-login/DesktopGoogleLogin.tsx
+++ b/src/common/login/signin-button/desktop-google-login/DesktopGoogleLogin.tsx
@@ -7,7 +7,7 @@ import "./desktop-google-login.scss"
 const DesktopGoogleLogin = (props: { }) => {
 
     return (
-        <Button className="peak-electron-welcome-button" type="primary" icon={<GoogleOutlined />} onClick={() => window.open(`${config.base_url}/#/welcome?desktop-login=true`, '_blank')} >
+        <Button className="peak-electron-welcome-button" type="primary" icon={<GoogleOutlined />} onClick={() => window.open(`${config.web_url}/#/welcome?desktop-login=true`, '_blank')} >
             Continue securely with Google
         </Button>
     )

--- a/src/common/login/signin-button/webapp-google-signin/WebappGoogleLogin.tsx
+++ b/src/common/login/signin-button/webapp-google-signin/WebappGoogleLogin.tsx
@@ -40,12 +40,12 @@ const WebappGoogleLogin = (props: { isDesktopLogin: boolean, addAccountFlow: boo
             dispatch(addUserAccount(authedUser));
             if (isDesktopLogin) {
                 if (addAccountFlow) {
-                    const desktopDeepLinkUrl = `${config.protocol}://temp-desktop-login`
+                    const desktopDeepLinkUrl = `${config.electron_protocol}://temp-desktop-login`
                     console.log(`SENDING THEM TO: ${desktopDeepLinkUrl}`)
                     window.location.replace(desktopDeepLinkUrl);
                     history.push(`/logged-in?one-time-code=${oneTimeCode}`);
                 } else {
-                    const desktopDeepLinkUrl = `${config.protocol}://login?returned-code=${oneTimeCode}`
+                    const desktopDeepLinkUrl = `${config.electron_protocol}://login?returned-code=${oneTimeCode}`
                     window.location.replace(desktopDeepLinkUrl);
                     history.push(`/logged-in?one-time-code=${oneTimeCode}`);
                 }

--- a/src/common/profile-dropdown/ProfileDropdown.tsx
+++ b/src/common/profile-dropdown/ProfileDropdown.tsx
@@ -17,7 +17,7 @@ export const ProfileDropdown = (props: {}) => {
     const userAccounts: DisplayPeaker[] = useUserAccounts()
 
     const signinAdditionalAccount = () => {
-        window.open(`${config.base_url}/#/welcome?desktop-login=${isElectron}&${EXISTING_PEAK_USER_ID}=${user.peak_user_id}&add-account=true`, '_blank')
+        window.open(`${config.web_protocol}${config.app_server_domain}/#/welcome?desktop-login=${isElectron}&${EXISTING_PEAK_USER_ID}=${user.peak_user_id}&add-account=true`, '_blank')
     }
 
     const menu = (

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,4 +1,2 @@
-export const backend_host_address: string = process.env.REACT_APP_BACKEND_HOST_ADDRESS || "localhost:4000";
 export const ELECTRON = "electron"
-
 export const EXISTING_PEAK_USER_ID = "existing-peak-user-id"

--- a/src/constants/environment-vars.ts
+++ b/src/constants/environment-vars.ts
@@ -1,16 +1,30 @@
 import {ELECTRON} from "./constants";
 
-const dev = {
-    base_url: "http://localhost:3001",
+interface PeakAppConfig {
+    app_server_domain: string
+    web_protocol: string
+    backend_domain: string
+    electron_protocol: string
+    env: string
+    dist: string
+
+}
+
+const dev: PeakAppConfig = {
+    web_protocol: "http://",
+    app_server_domain: "localhost:3001",
+    backend_domain: "localhost:4000",
     env: "dev",
-    protocol: "peak-dev-app",
+    electron_protocol: "peak-dev-app",
     dist: process.env.REACT_APP_DIST || ELECTRON
 }
 
-const prod = {
-    base_url: "https://peak-app-server.onrender.com",
+const prod: PeakAppConfig = {
+    web_protocol: "https://",
+    app_server_domain: process.env.REACT_APP_APP_SERVER_ADDRESS || "you-need-to-set-this.com",
+    backend_domain: process.env.REACT_APP_BACKEND_SERVER_ADDRESS || "you-need-to-set-this.com",
     env: "prod",
-    protocol: "peak-app",
+    electron_protocol: "peak-app",
     dist: process.env.REACT_APP_DIST || ELECTRON
 }
 

--- a/src/utils/socketUtil.ts
+++ b/src/utils/socketUtil.ts
@@ -1,7 +1,7 @@
 import {Channel, Socket} from 'phoenix';
 import peakAxiosClient from "../client/axiosConfig";
 import {AxiosResponse} from "axios";
-import {backend_host_address} from "../constants/constants";
+import config from "../constants/environment-vars"
 
 interface SocketTokenPayload {
     id: string
@@ -19,7 +19,7 @@ export function establishSocketConnection(userId: string): Promise<Socket> {
         const socketAccessToken: SocketTokenPayload = res.data
 
         // TODO: Needs to be configured as another BACKEND URL
-        const socketConn = new Socket(`ws://${backend_host_address}/socket`, {
+        const socketConn = new Socket(`ws://${config.backend_domain}/socket`, {
             // logger: ((kind, msg, data) => { console.log(`${kind}: ${msg}`, data) }),
             params: socketAccessToken,
         })

--- a/src/views/logged-in/LoggedIn.tsx
+++ b/src/views/logged-in/LoggedIn.tsx
@@ -10,7 +10,7 @@ export const LoggedIn = (props: { }) => {
     const query = useQuery();
     const oneTimeCode: string | null = query.get("one-time-code")
     // const addUserFlow: string | null = query.get("add-account")
-    const desktopDeepLinkUrl = (oneTimeCode) ? `${config.protocol}://login?returned-code=${oneTimeCode}` : `${config.protocol}://temp-desktop-login`
+    const desktopDeepLinkUrl = (oneTimeCode) ? `${config.electron_protocol}://login?returned-code=${oneTimeCode}` : `${config.electron_protocol}://temp-desktop-login`
 
     return (
         <div className={"logged-in-page-container"}>


### PR DESCRIPTION
## Changes
- `REACT_APP_APP_SERVER_ADDRESS` & `REACT_APP_BACKEND_SERVER_ADDRESS` are now just the domain so we can use them for websockets and RESTful requests
- Move `backend_host_address` into `config`