### PR TITLE
Set overflow:auto on body when opening drawer so users can still scroll

### DIFF
--- a/src/chrome-extension/content-script/components/save-note-modal/save-note-editor/save-note-editor.scss
+++ b/src/chrome-extension/content-script/components/save-note-modal/save-note-editor/save-note-editor.scss
@@ -3,6 +3,7 @@
   height: 69%;
   overflow: auto;
   flex: 1 1 auto;
+  padding-bottom: 25px;
 
   .peak-note-editor {
     height: 100%;

--- a/src/chrome-extension/content-script/content.tsx
+++ b/src/chrome-extension/content-script/content.tsx
@@ -22,6 +22,7 @@ import moment from "moment";
 
 // ---------------------------------------------------
 // Mount Drawer to DOM
+// - This does not show the modal.
 // ---------------------------------------------------
 chrome.storage.sync.get(function (data) {
     console.log(`----------> MOUNTING THE MODALLLL`)

--- a/src/chrome-extension/content-script/utils/drawerUtils.tsx
+++ b/src/chrome-extension/content-script/utils/drawerUtils.tsx
@@ -28,7 +28,6 @@ export function openDrawer(currTab: Tab, userId: string, tags: PeakTag[]): void 
             shouldSubmit: shouldSubmit,
             closeDrawer: () => removeDrawer(activeTabId.toString()),
         } as SaveNoteDrawerProps
-
         const app = document.getElementById('my-extension-root')
         ReactDOM.render(<SaveNoteDrawer {...props} />, app)
     }
@@ -45,6 +44,9 @@ export function openDrawer(currTab: Tab, userId: string, tags: PeakTag[]): void 
             console.log(`SUBMITTING`)
             createDrawer(currTab.id, true)
         }
+
+        // Needed so users can still scroll w/Drawer open
+        document.body.style.setProperty("overflow", "auto")
     })
 
     setItemInChromeState(TAGS_KEY, tags)


### PR DESCRIPTION
## Changes
- Set `overflow:auto` on body when opening drawer so users can still scroll