### PR TITLE
Update quick switcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": ".",
   "main": "build/electron/main.js",
-  "version": "0.0.4-beta",
+  "version": "0.0.5-beta",
   "scripts": {
     "extension:dev": "./scripts/chrome-extension/development.sh",
     "extension:build": "./scripts/chrome-extension/production.sh",

--- a/src/common/peak-modal/PeakModal.tsx
+++ b/src/common/peak-modal/PeakModal.tsx
@@ -5,16 +5,9 @@ import "./peak-modal.scss"
 export const PeakModal = (props: { isOpen: boolean, onClose: () => void, children, }) => {
     const { isOpen, onClose } = props
 
-    // TODO --> useEffect to instantly close out modal
-
     return (
-        <div className={cn("peak-modal-mask", isOpen ? "open" : "closed" )} onClick={ e => {
-            console.log(`MASK WAS CLICKED`)
-            onClose()
-        }} >
-            <div className={cn("peak-modal")} onClick={e => {
-                e.stopPropagation()
-            }}>
+        <div className={cn("peak-modal-mask", isOpen ? "open" : "closed" )} onClick={ e => onClose() }>
+            <div className={cn("peak-modal")} onClick={e => e.stopPropagation()}>
                 {props.children}
             </div>
         </div>

--- a/src/common/peak-modal/PeakModal.tsx
+++ b/src/common/peak-modal/PeakModal.tsx
@@ -1,0 +1,22 @@
+import React, {useState} from 'react'
+import cn from "classnames";
+import "./peak-modal.scss"
+
+export const PeakModal = (props: { isOpen: boolean, onClose: () => void, children, }) => {
+    const { isOpen, onClose } = props
+
+    // TODO --> useEffect to instantly close out modal
+
+    return (
+        <div className={cn("peak-modal-mask", isOpen ? "open" : "closed" )} onClick={ e => {
+            console.log(`MASK WAS CLICKED`)
+            onClose()
+        }} >
+            <div className={cn("peak-modal")} onClick={e => {
+                e.stopPropagation()
+            }}>
+                {props.children}
+            </div>
+        </div>
+    )
+}

--- a/src/common/peak-modal/peak-modal.scss
+++ b/src/common/peak-modal/peak-modal.scss
@@ -19,6 +19,7 @@
 
     width: 75%;
     max-width: 600px;
+    min-width: 600px;
     box-shadow: rgb(15, 15, 15 / 5%) 0px 0px 0px 1px, rgb(15, 15, 15 / 10%) 0px 5px 10px, rgb(15, 15, 15 / 20%) 0px 15px 40px;
 
     border-radius: 3px;

--- a/src/common/peak-modal/peak-modal.scss
+++ b/src/common/peak-modal/peak-modal.scss
@@ -1,0 +1,30 @@
+.peak-modal-mask {
+  position: absolute;
+  inset: 0px;
+  background: rgba(15, 15, 15, 0.6);
+  z-index: 100!important;
+  display: flex;
+  //align-items: center;
+  justify-content: center;
+
+  &.closed {
+    visibility: hidden;
+  }
+
+  .peak-modal {
+    position: relative;
+    z-index: 1;
+    height: fit-content;
+
+    width: 75%;
+    max-width: 600px;
+    box-shadow: rgb(15, 15, 15 / 5%) 0px 0px 0px 1px, rgb(15, 15, 15 / 10%) 0px 5px 10px, rgb(15, 15, 15 / 20%) 0px 15px 40px;
+
+    border-radius: 3px;
+    background: white;
+    top: 90px;
+    overflow: hidden;
+    min-height: 50px;
+    max-height: 80vh;
+  }
+}

--- a/src/common/peak-modal/peak-modal.scss
+++ b/src/common/peak-modal/peak-modal.scss
@@ -9,6 +9,7 @@
 
   &.closed {
     visibility: hidden;
+    //display: none;
   }
 
   .peak-modal {

--- a/src/common/quick-switcher/QuickSwitcher.tsx
+++ b/src/common/quick-switcher/QuickSwitcher.tsx
@@ -1,8 +1,8 @@
 import React, {useEffect, useState} from 'react'
-import {AutoComplete, Modal } from "antd";
+import {AutoComplete } from "antd";
 import { useDispatch, useSelector} from "react-redux";
 import { AppState} from "../../redux";
-import {closeSwitcher, quickSwitcherSlice} from "../../redux/slices/quickSwitcherSlice";
+import {closeSwitcher} from "../../redux/slices/quickSwitcherSlice";
 import "./quick-switcher.scss"
 import {convertHierarchyToSearchableList} from "../../utils/hierarchy";
 import { cloneDeep} from "lodash";
@@ -10,6 +10,7 @@ import { useHistory } from 'react-router-dom';
 import {renderPeakDisplayNodesInList} from "./quick-switch-item/QuickSwitchItem";
 import {PeakDisplayNode, PeakTopicNode} from "../../redux/slices/user/types";
 import {useNotes} from "../../client/notes";
+import {PeakModal} from "../peak-modal/PeakModal";
 
 const QuickSwitcher = (props: { }) => {
     const hierarchy = useSelector<AppState, PeakTopicNode[]>(state => state.currentUser.hierarchy);
@@ -31,15 +32,9 @@ const QuickSwitcher = (props: { }) => {
     }, [ hierarchy, notes ]);
 
     useEffect(() => {
-        let timer = null;
         if (isOpen) {
-            timer = setTimeout(() => {
-                setChildOpen(true)
-            }, 275);
+            setChildOpen(true)
         }
-        return () => {
-            clearTimeout(timer!)
-        };
     }, [ isOpen ]);
 
     const closeModal = () => {
@@ -68,18 +63,11 @@ const QuickSwitcher = (props: { }) => {
         }
     }
 
+
     return (
-        <Modal
-            visible={isOpen}
-            maskClosable={true}
-            onCancel={closeModal}
-            footer={null}
-            closable={false}
-            keyboard={true}
-            destroyOnClose={false}
-            className={"quick-switch-modal"}>
-             <DropdownThatActuallyListens filteredAntList={filteredAntList} closeModal={closeModal} handleSearch={handleSearch} goTo={goTo} value={value} isOpen={childOpen}/>
-        </Modal>
+        <PeakModal isOpen={isOpen} onClose={() => closeModal()}>
+            <DropdownThatActuallyListens filteredAntList={filteredAntList} closeModal={closeModal} handleSearch={handleSearch} goTo={goTo} value={value} isOpen={childOpen}/>
+        </PeakModal>
     )
 };
 
@@ -108,7 +96,7 @@ const DropdownThatActuallyListens = (props) => {
                         closeModal()
                     }
                 }}
-                open={isOpen}
+                open={true}
                 style={{width: '100%'}}
                 value={value}
                 dropdownClassName={"peak-dropdown"}

--- a/src/common/quick-switcher/QuickSwitcher.tsx
+++ b/src/common/quick-switcher/QuickSwitcher.tsx
@@ -32,19 +32,14 @@ const QuickSwitcher = (props: { }) => {
     }, [ hierarchy, notes ]);
 
     useEffect(() => {
-        if (isOpen) {
-            setChildOpen(true)
-        }
+        setChildOpen(isOpen)
     }, [ isOpen ]);
 
     const closeModal = () => {
         setChildOpen(false)
         setFilteredAntList(antList)
-
-        setTimeout(() => {
-            setValue(undefined)
-            dispatch(closeSwitcher())
-        }, 50);
+        setValue(undefined)
+        dispatch(closeSwitcher())
     }
 
     const goTo = async (val: string, option: any) => {

--- a/src/common/quick-switcher/quick-switcher.scss
+++ b/src/common/quick-switcher/quick-switcher.scss
@@ -4,58 +4,38 @@ $border-radius: 5px;
 $padding-left: 15px;
 $icon-dimension: 16px;
 
-.quick-switch-modal {
-  background-color: white;
-  border-radius: $border-radius;
-  width: $modal-width;
-  padding-bottom: 0px!important;
-  min-height: 50px;
+.quick-switch-modal-container {
+  display: flex;
+  align-items: center;
+  min-height: inherit;
+  height: inherit;
+  width: 100%;
+  //padding: 6px $padding-left 10px;
 
-  .ant-modal-content {
-    min-height: inherit;
-    height: inherit;
-    border-radius: 8px;
+  .quick-switch-search-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: silver;
+    font-size: $icon-dimension;
+  }
 
-    .ant-modal-body {
-      min-height: inherit;
-      height: inherit;
-      padding: 0!important;
+  .quick-switch-input {
+    //font-size: 18px;
+    //margin-top: 3px;
 
-      .quick-switch-modal-container {
-        display: flex;
-        align-items: center;
-        min-height: inherit;
-        height: inherit;
-        width: 100%;
-        //padding: 6px $padding-left 10px;
+    .ant-select-selector {
+      outline: none!important;
+      border: none!important;
+      box-shadow: none!important;
 
-        .quick-switch-search-icon {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          color: silver;
-          font-size: $icon-dimension;
-        }
+      .ant-select-selection-search {
+        padding-left: 10px;
+      }
 
-        .quick-switch-input {
-          font-size: 18px;
-          margin-top: 3px;
-
-          .ant-select-selector {
-            outline: none!important;
-            border: none!important;
-            box-shadow: none!important;
-            padding-left: 15px;
-
-            .ant-select-selection-search {
-              padding-left: 5px;
-            }
-
-            .ant-select-selection-placeholder {
-              //padding-left: 15px;
-            }
-          }
-        }
+      .ant-select-selection-placeholder {
+        text-align: left;
+        padding-left: 10px;
       }
     }
   }

--- a/src/common/quick-switcher/quick-switcher.scss
+++ b/src/common/quick-switcher/quick-switcher.scss
@@ -10,7 +10,6 @@ $icon-dimension: 16px;
   min-height: inherit;
   height: inherit;
   width: 100%;
-  //padding: 6px $padding-left 10px;
 
   .quick-switch-search-icon {
     display: flex;

--- a/src/common/sidebar/topic-section/topic-page-group/topic-page-group.scss
+++ b/src/common/sidebar/topic-section/topic-page-group/topic-page-group.scss
@@ -20,6 +20,9 @@
       height: 40px;
       line-height: 40px;
 
+      overflow: hidden;
+      text-overflow: ellipsis;
+
       &:hover {
         color: $primary-blue;
         cursor: pointer;

--- a/src/index.scss
+++ b/src/index.scss
@@ -20,7 +20,6 @@ body {
 
   text-overflow: ellipsis!important;
   white-space: nowrap!important;
-  overflow: hidden;
   //text-overflow: ellipsis!important;
 }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -19,6 +19,9 @@ body {
   color: $text-color!important;
 
   text-overflow: ellipsis!important;
+  white-space: nowrap!important;
+  overflow: hidden;
+  //text-overflow: ellipsis!important;
 }
 
 code {

--- a/src/utils/loading-util.ts
+++ b/src/utils/loading-util.ts
@@ -6,6 +6,7 @@ import {store} from "../redux/store";
 import {openSwitcher} from "../redux/slices/quickSwitcherSlice";
 import {useEffect} from "react";
 import {load_active_user, switch_user_accounts} from "../redux/rootReducer";
+import { useHistory } from "react-router-dom";
 
 export function loadEntireWorldForAllAccounts(ogUserId: string, peakUserId: string): Promise<void> {
     return loadAllUserAccounts(ogUserId, peakUserId).then(res => {
@@ -33,13 +34,15 @@ export function loadEntireWorldForAllAccounts(ogUserId: string, peakUserId: stri
 
 export const useAccountSwitcher = () => {
     const dispatch = useDispatch()
+    const history = useHistory()
     return async (selectedAccount: DisplayPeaker, currentAccountId: string) => {
         if (selectedAccount.id !== currentAccountId) {
             // @ts-ignore
             document.activeElement.blur()
             await syncCurrentStateToLocalStorage(currentAccountId)
             await dispatch(switch_user_accounts(selectedAccount))
-            window.history.pushState({}, null, "/home/journal")
+            // window.history.pushState({}, null, "#/home/journal")
+            history.push("/")
         }
     }
 }

--- a/src/views/journal/Journal.tsx
+++ b/src/views/journal/Journal.tsx
@@ -277,6 +277,8 @@ const Journal = (props: InternalJournalProps) => {
     } = props
     const editorState = useActiveEditorState()
 
+    console.log(`Current Journal State `, journalContent)
+
     return (
         <Slate
             editor={editor}


### PR DESCRIPTION
## Changes
- Update the QuickSwitcher to use the snappier `<PeakModal/>` instead of [Ant's <Modal/> component](https://ant.design/components/modal)
- [Temporarily] Trigger a full-reload when switching between accounts to see if this explains the weird amount of errors in the secondary user journal