### PR TITLE
Small cleanup of chrome extension

### DIFF
--- a/src/chrome-extension/content-script/components/save-page-message/SavePageMessage.tsx
+++ b/src/chrome-extension/content-script/components/save-page-message/SavePageMessage.tsx
@@ -26,7 +26,12 @@ import 'antd/lib/list/style/index.css';
 import 'antd/lib/skeleton/style/index.css';
 import "./save-page-message.scss";
 import "../../../../constants/peak-editor.scss"
-import {sendDeletePageMessage, sendSubmitNoteMessage, updateMessageInPlace} from "../../utils/messageUtils";
+import {
+    buildDeletePageCalback,
+    sendDeletePageMessage,
+    sendSubmitNoteMessage,
+    updateMessageInPlace
+} from "../../utils/messageUtils";
 import {INITIAL_PAGE_STATE} from "../../../../constants/editor";
 import {NullButton} from "./components/save-page-header-content/undo-close-button/UndoCloseButton";
 import Tab = chrome.tabs.Tab;
@@ -57,8 +62,8 @@ export interface SavedPageContentProps {
 export interface SavedPageProps extends SavedPageContentProps, SavedPageStateProps { };
 export const NOTIFICATION_KEY = "saved-page-message"
 
-function deriveDuration(saving: SUBMISSION_STATE, editing: EDITING_STATE, tagFocus: FOCUS_STATE): number {
-   if (tagFocus === FOCUS_STATE.Focus) {
+function deriveDuration(saving: SUBMISSION_STATE, editing: EDITING_STATE, focus: FOCUS_STATE): number {
+   if (focus === FOCUS_STATE.Focus) {
        return 0
    }
 
@@ -68,6 +73,7 @@ function deriveDuration(saving: SUBMISSION_STATE, editing: EDITING_STATE, tagFoc
    return 2
 }
 
+// The function that actually renders the Ant.Notification on the page
 export const openMessage = (props: SavedPageProps) => {
     const { saving, editingState, tabId, focusState, userId, noteId, tags } = props
     const duration = deriveDuration(saving, editingState, focusState)
@@ -180,11 +186,4 @@ export const closeMessage = (tabId: number) => {
     deleteItem([tabId.toString(), ACTIVE_TAB_KEY], () => {
         notification.close(NOTIFICATION_KEY)
     })
-}
-
-function buildDeletePageCalback(tabId: number, userId: string, noteId: string): () => void {
-    return () => {
-        updateMessageInPlace(tabId, { editingState: EDITING_STATE.Deleting })
-        sendDeletePageMessage(tabId, userId, noteId)
-    }
 }

--- a/src/chrome-extension/content-script/components/save-page-message/components/save-page-content/SavePageContent.tsx
+++ b/src/chrome-extension/content-script/components/save-page-message/components/save-page-content/SavePageContent.tsx
@@ -9,7 +9,7 @@ import "./save-page-content.scss"
 import {Node} from "slate";
 import {INITIAL_PAGE_STATE} from "../../../../../../constants/editor";
 import {PeakLogo} from "../../../../../../common/logo/PeakLogo";
-import {EDITING_STATE, FOCUS_STATE, SUBMISSION_STATE} from "../../../../../constants/constants";
+import {EDITING_STATE, SUBMISSION_STATE} from "../../../../../constants/constants";
 import {sendSubmitNoteMessage, updateMessageInPlace} from "../../../../utils/messageUtils";
 import {PageSavingAnimation} from "../page-saving-animation/PageSavingAnimation";
 import {STUB_TAG_ID} from "../../../../../../redux/slices/tags/types";
@@ -98,12 +98,6 @@ const PageTitle = (props: { tabId: number, editedPageTitle: string, setPageTitle
         <div className={"peak-extension-row-container title"}>
             <img className={"page-peak-favicon"} src={favIconUrl || baseUrl}/>
             <Input
-                onBlur={() => {
-                    updateMessageInPlace(tabId, { focusState: FOCUS_STATE.NotFocused })
-                }}
-                onFocus={() => {
-                    updateMessageInPlace(tabId, { focusState: FOCUS_STATE.Focus })
-                }}
                 className={"page-peak-title-input"}
                 bordered={false}
                 value={editedPageTitle}

--- a/src/chrome-extension/content-script/utils/messageUtils.ts
+++ b/src/chrome-extension/content-script/utils/messageUtils.ts
@@ -4,7 +4,7 @@ import {DeletePageMessage, MessageType, SubmitNoteMessage} from "../../constants
 import {getItem, setItem} from "../../utils/storageUtils";
 import {
     ACTIVE_TAB_KEY,
-    ActiveTabState,
+    ActiveTabState, EDITING_STATE,
     SUBMISSION_STATE,
     TAGS_KEY
 } from "../../constants/constants";
@@ -53,3 +53,9 @@ export const updateMessageInPlace = (tabId: number, payload: {}) => {
     })
 }
 
+export function buildDeletePageCalback(tabId: number, userId: string, noteId: string): () => void {
+    return () => {
+        updateMessageInPlace(tabId, { editingState: EDITING_STATE.Deleting })
+        sendDeletePageMessage(tabId, userId, noteId)
+    }
+}

--- a/src/common/rich-text-editor/plugins/peak-knowledge-plugin/components/peak-knowledge-node/peak-tag-select/component/ChromeExtensionTagSelect.tsx
+++ b/src/common/rich-text-editor/plugins/peak-knowledge-plugin/components/peak-knowledge-node/peak-tag-select/component/ChromeExtensionTagSelect.tsx
@@ -6,9 +6,6 @@ import {STUB_TAG_ID, TEMP_HOLDER} from "../../../../../../../../redux/slices/tag
 import {LabeledValue} from "antd/es/select";
 import {calculateNextColor} from "../utils";
 import cn from "classnames";
-import {take} from "ramda";
-import { updateMessageInPlace } from "../../../../../../../../chrome-extension/content-script/utils/messageUtils";
-import {FOCUS_STATE} from "../../../../../../../../chrome-extension/constants/constants";
 const { Option } = Select;
 
 export interface ChromeExtensionTagSelectProps {
@@ -100,11 +97,9 @@ export const TagSelect = (props: ChromeExtensionTagSelectProps) => {
                         open={open}
                         onBlur={() => {
                             setDropdownState(false)
-                            updateMessageInPlace(tabId, { focusState: FOCUS_STATE.NotFocused })
                         }}
                         onFocus={() => {
                             setDropdownState(true)
-                            updateMessageInPlace(tabId, { focusState: FOCUS_STATE.Focus })
                         }}
                         onSearch={(value) => {
                             setDropdownState(true)


### PR DESCRIPTION
## Changes
- Remove a lot of `updateMessageInPlace` calls. Individual components shouldn't have to worry about whether or not to keep the notification open. That should be handled in a centralized place elsewhere.